### PR TITLE
chore: simplify releasing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     paths-ignore:
       - "README.md"
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
 
 concurrency:
   group: ${{github.workflow}}-${{github.head_ref}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -16,7 +12,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.7
         with:
-          # Allow goreleaser to access older tag information.
+          fetch-depth: 0
+      # push the latest tag to the remote
+      - id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      # refetch the repo to make sure we have the latest tag
+      - uses: actions/checkout@v4.1.7
+        with:
           fetch-depth: 0
       - uses: actions/setup-go@v5.0.2
         with:

--- a/README.md
+++ b/README.md
@@ -221,3 +221,13 @@ The Makefile includes several tasks to facilitate development and testing. For l
 - **e2e-apply-cosmo-local**: Runs end-to-end tests for cosmo local. (References: `examples/cosmo-local`)
 - **e2e-destroy-cosmo-local**: Runs end-to-end tests for cosmo local destroy. (References: `examples/cosmo-local`)
 - **e2e-clean-cosmo-local**: Cleans up the cosmo local setup. (References: `examples/cosmo-local`)
+
+## Releasing
+
+The Terraform Provider can be release by triggering the `Release` workflow in the `.github/workflows` directory.
+This workflow must be triggered manually on the main branch when a release is needed.
+
+The workflow will create a new tag and push it to the remote.
+Subsequently the workflow will build the go release and create a new github release.
+
+Tags follow this schema: `vX.Y.Z`. This is needed for the terraform registry to pick up new versions.


### PR DESCRIPTION
# Motivation

This avoids handling tags and bumps the version on workflow trigger release. 

For now the process is manually triggered to be able to run tests on main prior to releasing.