### PR TITLE
doc: Remove terraform.local from documnetation

### DIFF
--- a/docs/data-sources/federated_graph.md
+++ b/docs/data-sources/federated_graph.md
@@ -16,7 +16,7 @@ Cosmo Federated Graph Data Source
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/docs/data-sources/monograph.md
+++ b/docs/data-sources/monograph.md
@@ -16,7 +16,7 @@ Cosmo Monograph Data Source
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/docs/data-sources/namespace.md
+++ b/docs/data-sources/namespace.md
@@ -16,7 +16,7 @@ Cosmo Namespace Data Source
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/docs/data-sources/subgraph.md
+++ b/docs/data-sources/subgraph.md
@@ -16,7 +16,7 @@ Cosmo Subgraph Data Source
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Refer to the official [Cosmo Documentation](https://cosmo-docs.wundergraph.com/)
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/docs/resources/federated_graph.md
+++ b/docs/resources/federated_graph.md
@@ -19,7 +19,7 @@ For more information on federated graphs, please refer to the [Cosmo Documentati
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -19,7 +19,7 @@ For more information on namespaces, please refer to the [Cosmo Documentation](ht
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/docs/resources/router_token.md
+++ b/docs/resources/router_token.md
@@ -19,7 +19,7 @@ For more information on router tokens, please refer to the [Cosmo Documentation]
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/docs/resources/subgraph.md
+++ b/docs/resources/subgraph.md
@@ -19,7 +19,7 @@ For more information on subgraphs, please refer to the [Cosmo Documentation](htt
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/examples/cosmo-local/provider.tf
+++ b/examples/cosmo-local/provider.tf
@@ -13,7 +13,7 @@ terraform {
       version = "2.15.0"
     }
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
     time = {

--- a/examples/cosmo/provider.tf
+++ b/examples/cosmo/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/examples/data-sources/cosmo_federated_graph/data-source.tf
+++ b/examples/data-sources/cosmo_federated_graph/data-source.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/examples/data-sources/cosmo_monograph/data-source.tf
+++ b/examples/data-sources/cosmo_monograph/data-source.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/examples/data-sources/cosmo_namespace/data-source.tf
+++ b/examples/data-sources/cosmo_namespace/data-source.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/examples/data-sources/cosmo_subgraph/data-source.tf
+++ b/examples/data-sources/cosmo_subgraph/data-source.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/examples/resources/comso_monograph/provider.tf
+++ b/examples/resources/comso_monograph/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/examples/resources/cosmo_federated_graph/resource.tf
+++ b/examples/resources/cosmo_federated_graph/resource.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/examples/resources/cosmo_namespace/resource.tf
+++ b/examples/resources/cosmo_namespace/resource.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/examples/resources/cosmo_router_token/resource.tf
+++ b/examples/resources/cosmo_router_token/resource.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/examples/resources/cosmo_subgraph/resource.tf
+++ b/examples/resources/cosmo_subgraph/resource.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }

--- a/modules/cosmo-federated-graph/providers.tf
+++ b/modules/cosmo-federated-graph/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cosmo = {
-      source  = "terraform.local/wundergraph/cosmo"
+      source  = "wundergraph/cosmo"
       version = "0.0.1"
     }
   }


### PR DESCRIPTION
Fix #6


## New Behavior

```bash
[provider]$ terraform init
Initializing the backend...
Initializing modules...
Initializing provider plugins...
- Reusing previous version of wundergraph/cosmo from the dependency lock file
- Reusing previous version of hashicorp/random from the dependency lock file
- Using previously-installed wundergraph/cosmo v0.0.1
- Using previously-installed hashicorp/random v3.6.3

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

```