### PR TITLE
Import by id now works by finding the relevant subgraph in the provided namespace

### DIFF
--- a/docs/resources/subgraph.md
+++ b/docs/resources/subgraph.md
@@ -10,7 +10,7 @@ description: |-
 # cosmo_subgraph (Resource)
 
 This resource handles subgraphs. Each subgraph is responsible for defining its specific segment of the schema and managing the related queries.
-		
+
 For more information on subgraphs, please refer to the [Cosmo Documentation](https://cosmo-docs.wundergraph.com/cli/subgraph).
 
 ## Example Usage

--- a/internal/api/subgraph.go
+++ b/internal/api/subgraph.go
@@ -114,6 +114,27 @@ func (p PlatformClient) GetSubgraph(ctx context.Context, name, namespace string)
 	return response.Msg.GetGraph(), nil
 }
 
+func (p PlatformClient) GetSubgraphs(ctx context.Context, namespace string) ([]*platformv1.Subgraph, *ApiError) {
+	request := connect.NewRequest(&platformv1.GetSubgraphsRequest{
+		Namespace: namespace,
+	})
+	response, err := p.Client.GetSubgraphs(ctx, request)
+	if err != nil {
+		return nil, &ApiError{Err: err, Reason: "GetSubgraph", Status: common.EnumStatusCode_ERR}
+	}
+
+	if response.Msg == nil {
+		return nil, &ApiError{Err: ErrEmptyMsg, Reason: "GetSubgraph", Status: common.EnumStatusCode_ERR}
+	}
+
+	apiError := handleErrorCodes(response.Msg.GetResponse().Code, response.Msg.String())
+	if apiError != nil {
+		return nil, apiError
+	}
+
+	return response.Msg.GetGraphs(), nil
+}
+
 func (p PlatformClient) PublishSubgraph(ctx context.Context, name, namespace, schema string) (*platformv1.PublishFederatedSubgraphResponse, *ApiError) {
 	request := connect.NewRequest(&platformv1.PublishFederatedSubgraphRequest{
 		Name:      name,

--- a/internal/api/subgraph.go
+++ b/internal/api/subgraph.go
@@ -118,6 +118,7 @@ func (p PlatformClient) GetSubgraphs(ctx context.Context, namespace string) ([]*
 	request := connect.NewRequest(&platformv1.GetSubgraphsRequest{
 		Namespace: namespace,
 	})
+
 	response, err := p.Client.GetSubgraphs(ctx, request)
 	if err != nil {
 		return nil, &ApiError{Err: err, Reason: "GetSubgraph", Status: common.EnumStatusCode_ERR}
@@ -133,6 +134,29 @@ func (p PlatformClient) GetSubgraphs(ctx context.Context, namespace string) ([]*
 	}
 
 	return response.Msg.GetGraphs(), nil
+}
+
+func (p PlatformClient) GetSubgraphSchema(ctx context.Context, name, namespace string) (string, *ApiError) {
+	request := connect.NewRequest(&platformv1.GetLatestSubgraphSDLRequest{
+		Name:      name,
+		Namespace: namespace,
+	})
+
+	response, err := p.Client.GetLatestSubgraphSDL(ctx, request)
+	if err != nil {
+		return "", &ApiError{Err: err, Reason: "GetSubgraph", Status: common.EnumStatusCode_ERR}
+	}
+
+	if response.Msg == nil {
+		return "", &ApiError{Err: ErrEmptyMsg, Reason: "GetSubgraph", Status: common.EnumStatusCode_ERR}
+	}
+
+	apiError := handleErrorCodes(response.Msg.GetResponse().Code, response.Msg.String())
+	if apiError != nil {
+		return "", apiError
+	}
+
+	return response.Msg.GetSdl(), nil
 }
 
 func (p PlatformClient) PublishSubgraph(ctx context.Context, name, namespace, schema string) (*platformv1.PublishFederatedSubgraphResponse, *ApiError) {

--- a/internal/service/subgraph/errors.go
+++ b/internal/service/subgraph/errors.go
@@ -4,6 +4,7 @@ const (
 	ErrInvalidSubgraphName       = "Invalid Subgraph Name"
 	ErrCreatingSubgraph          = "Error Creating Subgraph"
 	ErrRetrievingSubgraph        = "Error Retrieving Subgraph"
+	ErrRetrievingSubgraphs       = "Error Retrieving Subgraphs"
 	ErrUpdatingSubgraph          = "Error Updating Subgraph"
 	ErrDeletingSubgraph          = "Error Deleting Subgraph"
 	ErrPublishingSubgraph        = "Error Publishing Subgraph"

--- a/internal/service/subgraph/resource_cosmo_subgraph.go
+++ b/internal/service/subgraph/resource_cosmo_subgraph.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -209,21 +210,28 @@ func (r *SubgraphResource) Read(ctx context.Context, req resource.ReadRequest, r
 				break
 			}
 		}
-	} else {
-		subgraph, apiError = r.client.GetSubgraph(ctx, data.Name.ValueString(), data.Namespace.ValueString())
-	}
-	if apiError != nil {
-		if api.IsNotFoundError(apiError) {
-			utils.AddDiagnosticWarning(resp,
-				ErrSubgraphNotFound,
-				fmt.Sprintf("Subgraph '%s' not found will be recreated %s", data.Name.ValueString(), apiError.Error()),
-			)
-			resp.State.RemoveResource(ctx)
+
+		if subgraph == nil {
+			utils.AddDiagnosticError(resp, ErrSubgraphNotFound, fmt.Sprintf("Subgraph with ID '%s' not found", data.Id.ValueString()))
 			return
 		}
-		utils.AddDiagnosticError(resp, ErrRetrievingSubgraph, fmt.Sprintf("Could not fetch subgraph '%s': %s", data.Name.ValueString(), apiError.Error()))
-		return
+
+	} else {
+		subgraph, apiError = r.client.GetSubgraph(ctx, data.Name.ValueString(), data.Namespace.ValueString())
+		if apiError != nil {
+			if api.IsNotFoundError(apiError) {
+				utils.AddDiagnosticWarning(resp,
+					ErrSubgraphNotFound,
+					fmt.Sprintf("Subgraph '%s' not found will be recreated %s", data.Name.ValueString(), apiError.Error()),
+				)
+				resp.State.RemoveResource(ctx)
+				return
+			}
+			utils.AddDiagnosticError(resp, ErrRetrievingSubgraph, fmt.Sprintf("Could not fetch subgraph '%s': %s", data.Name.ValueString(), apiError.Error()))
+			return
+		}
 	}
+
 	schema, apiError := r.client.GetSubgraphSchema(ctx, subgraph.Name, subgraph.Namespace)
 	if apiError != nil {
 		if api.IsNotFoundError(apiError) {
@@ -237,12 +245,21 @@ func (r *SubgraphResource) Read(ctx context.Context, req resource.ReadRequest, r
 		utils.AddDiagnosticError(resp, ErrRetrievingSubgraph, fmt.Sprintf("Could not fetch subgraph '%s': %s", data.Name.ValueString(), apiError.Error()))
 		return
 	}
+	labels := map[string]attr.Value{}
+	for _, label := range subgraph.GetLabels() {
+		if label != nil {
+			labels[label.GetKey()] = types.StringValue(label.GetValue())
+		}
+	}
+	mapValue, diags := types.MapValueFrom(ctx, types.StringType, labels)
+	resp.Diagnostics.Append(diags...)
 
 	data.Id = types.StringValue(subgraph.GetId())
 	data.Name = types.StringValue(subgraph.GetName())
 	data.Namespace = types.StringValue(subgraph.GetNamespace())
 	data.RoutingURL = types.StringValue(subgraph.GetRoutingURL())
 	data.Schema = types.StringValue(schema)
+	data.Labels = mapValue
 
 	utils.LogAction(ctx, "read", data.Id.ValueString(), data.Name.ValueString(), data.Namespace.ValueString())
 

--- a/internal/service/subgraph/resource_cosmo_subgraph.go
+++ b/internal/service/subgraph/resource_cosmo_subgraph.go
@@ -258,7 +258,9 @@ func (r *SubgraphResource) Read(ctx context.Context, req resource.ReadRequest, r
 	data.Name = types.StringValue(subgraph.GetName())
 	data.Namespace = types.StringValue(subgraph.GetNamespace())
 	data.RoutingURL = types.StringValue(subgraph.GetRoutingURL())
-	data.Schema = types.StringValue(schema)
+	if len(schema) > 0 {
+		data.Schema = types.StringValue(schema)
+	}
 	data.Labels = mapValue
 
 	utils.LogAction(ctx, "read", data.Id.ValueString(), data.Name.ValueString(), data.Namespace.ValueString())


### PR DESCRIPTION
The provider failed on importing subgraphs when provided only an id. The read part in the subgraph resource assumed that we always had a name to get the subgraph by