### PR TITLE
feat: enforce recreation of subgraphs and feature subgraphs on namespace changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/hashicorp/hc-install v0.8.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/internal/service/contract/data_source_cosmo_contract_test.go
+++ b/internal/service/contract/data_source_cosmo_contract_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 

--- a/internal/service/contract/import_cosmo_contract_test.go
+++ b/internal/service/contract/import_cosmo_contract_test.go
@@ -3,8 +3,8 @@ package contract_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 

--- a/internal/service/contract/resource_cosmo_contract_test.go
+++ b/internal/service/contract/resource_cosmo_contract_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 

--- a/internal/service/feature-flag/data_source_cosmo_feature_flag_test.go
+++ b/internal/service/feature-flag/data_source_cosmo_feature_flag_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )

--- a/internal/service/feature-flag/import_cosmo_feature_flag_test.go
+++ b/internal/service/feature-flag/import_cosmo_feature_flag_test.go
@@ -3,8 +3,8 @@ package feature_flag_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )

--- a/internal/service/feature-flag/resource_cosmo_feature_flag_test.go
+++ b/internal/service/feature-flag/resource_cosmo_feature_flag_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )

--- a/internal/service/feature-subgraph/data_source_cosmo_feature_graph_test.go
+++ b/internal/service/feature-subgraph/data_source_cosmo_feature_graph_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )

--- a/internal/service/feature-subgraph/import_cosmo_feature_subgraph_test.go
+++ b/internal/service/feature-subgraph/import_cosmo_feature_subgraph_test.go
@@ -5,9 +5,9 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/api"

--- a/internal/service/feature-subgraph/resource_cosmo_feature_subgraph.go
+++ b/internal/service/feature-subgraph/resource_cosmo_feature_subgraph.go
@@ -91,6 +91,9 @@ For more information on feature subgraphs, please refer to the [Cosmo Documentat
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("default"),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"routing_url": schema.StringAttribute{
 				Required:            true,

--- a/internal/service/feature-subgraph/resource_cosmo_feature_subgraph_test.go
+++ b/internal/service/feature-subgraph/resource_cosmo_feature_subgraph_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/api"
@@ -279,6 +280,11 @@ func TestAccFeatureSubgraphNamespaceChangeForceNew(t *testing.T) {
 			// Change to the second namespace and verify recreation
 			{
 				Config: testAccFeatureSubgraphWithTwoNamespaces(initialNamespace, newNamespace, fgName, sgName, fsgName, routingURL, subgraphSchema, readme),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("cosmo_feature_subgraph.test", plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("cosmo_namespace.test2", "name", newNamespace),
 					resource.TestCheckResourceAttr("cosmo_feature_subgraph.test", "namespace", newNamespace),

--- a/internal/service/feature-subgraph/resource_cosmo_feature_subgraph_test.go
+++ b/internal/service/feature-subgraph/resource_cosmo_feature_subgraph_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/api"

--- a/internal/service/federated-graph/data_source_cosmo_federated_graph_test.go
+++ b/internal/service/federated-graph/data_source_cosmo_federated_graph_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 

--- a/internal/service/federated-graph/import_cosmo_federated_graph_test.go
+++ b/internal/service/federated-graph/import_cosmo_federated_graph_test.go
@@ -3,8 +3,8 @@ package federated_graph_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 

--- a/internal/service/federated-graph/resource_cosmo_federated_graph_test.go
+++ b/internal/service/federated-graph/resource_cosmo_federated_graph_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 

--- a/internal/service/monograph/data_source_cosmo_monograph_test.go
+++ b/internal/service/monograph/data_source_cosmo_monograph_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 

--- a/internal/service/monograph/import_cosmo_monograph_test.go
+++ b/internal/service/monograph/import_cosmo_monograph_test.go
@@ -6,9 +6,9 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 

--- a/internal/service/monograph/resource_cosmo_monograph_test.go
+++ b/internal/service/monograph/resource_cosmo_monograph_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 

--- a/internal/service/namespace/data_source_cosmo_namespace_test.go
+++ b/internal/service/namespace/data_source_cosmo_namespace_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 

--- a/internal/service/namespace/import_cosmo_namespace_test.go
+++ b/internal/service/namespace/import_cosmo_namespace_test.go
@@ -1,10 +1,11 @@
 package namespace_test
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 
 func TestAccCosmoNamespaceImportBasic(t *testing.T) {

--- a/internal/service/namespace/resource_cosmo_namespace_test.go
+++ b/internal/service/namespace/resource_cosmo_namespace_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )

--- a/internal/service/router-token/resource_cosmo_token_test.go
+++ b/internal/service/router-token/resource_cosmo_token_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 

--- a/internal/service/subgraph/data_source_cosmo_subgraph_test.go
+++ b/internal/service/subgraph/data_source_cosmo_subgraph_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 

--- a/internal/service/subgraph/import_cosmo_subgraph_test.go
+++ b/internal/service/subgraph/import_cosmo_subgraph_test.go
@@ -1,10 +1,11 @@
 package subgraph_test
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 
 func TestAccImportCosmoSubgraphBasic(t *testing.T) {

--- a/internal/service/subgraph/resource_cosmo_subgraph.go
+++ b/internal/service/subgraph/resource_cosmo_subgraph.go
@@ -94,6 +94,9 @@ For more information on subgraphs, please refer to the [Cosmo Documentation](htt
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("default"),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"routing_url": schema.StringAttribute{
 				Required:            true,

--- a/internal/service/subgraph/resource_cosmo_subgraph_test.go
+++ b/internal/service/subgraph/resource_cosmo_subgraph_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/wundergraph/cosmo/terraform-provider-cosmo/internal/acceptance"
 )
 
@@ -257,6 +258,11 @@ func TestAccSubgraphResourceNamespaceChangeForceNew(t *testing.T) {
 			},
 			{
 				Config: testSubgraphWithTwoNamespaces(initialNamespace, newNamespace, subgraphName, routingURL, subgraphSchema, nil, nil, nil, nil),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("cosmo_subgraph.test", plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("cosmo_namespace.test2", "name", newNamespace),
 					resource.TestCheckResourceAttr("cosmo_subgraph.test", "namespace", newNamespace),


### PR DESCRIPTION
When the namespace of a subgraph (and a feature subgraph) is changed, the provider now delete the old one and creates a new one in the new namespace.

Also I changed the imports to use the new terraform library dedicated to testing.