### PR TITLE
fix: subgraph schema was not retrieved in the datasource

### DIFF
--- a/internal/service/subgraph/data_source_cosmo_subgraph.go
+++ b/internal/service/subgraph/data_source_cosmo_subgraph.go
@@ -160,11 +160,18 @@ func (d *SubgraphDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
+	subgraphSchema, apiError := d.client.GetSubgraphSchema(ctx, subgraph.Name, subgraph.Namespace)
+	if apiError != nil {
+		utils.AddDiagnosticError(resp, ErrRetrievingSubgraphSchema, apiError.Error())
+		return
+	}
+
 	data.Id = types.StringValue(subgraph.GetBaseSubgraphId())
 	data.Name = types.StringValue(subgraph.GetName())
 	data.Namespace = types.StringValue(subgraph.GetNamespace())
 	data.RoutingUrl = types.StringValue(subgraph.GetRoutingURL())
 	data.BaseSubgraphName = types.StringValue(subgraph.GetBaseSubgraphName())
+	data.Schema = types.StringValue(subgraphSchema)
 
 	var labels map[string]attr.Value
 	for _, matcher := range subgraph.GetLabels() {

--- a/internal/service/subgraph/data_source_cosmo_subgraph_test.go
+++ b/internal/service/subgraph/data_source_cosmo_subgraph_test.go
@@ -17,13 +17,13 @@ func TestAccSubgraphDataSource(t *testing.T) {
 
 	subgraphName := acctest.RandomWithPrefix("test-subgraph")
 	subgraphRoutingURL := "https://example.com"
-
+	subgraphSchema := acceptance.TestAccValidSubgraphSchema
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acceptance.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubgraphDataSourceConfig(namespace, federatedGraphName, federatedGraphRoutingURL, subgraphName, subgraphRoutingURL),
+				Config: testAccSubgraphDataSourceConfig(namespace, federatedGraphName, federatedGraphRoutingURL, subgraphName, subgraphRoutingURL, subgraphSchema),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "name", subgraphName),
 					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "namespace", namespace),
@@ -34,13 +34,61 @@ func TestAccSubgraphDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "subscription_protocol", "ws"),
 					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "websocket_subprotocol", "auto"),
 					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "is_event_driven_graph", "false"),
+					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "schema", subgraphSchema),
+				),
+			},
+			{
+				Config:  testAccSubgraphDataSourceConfig(namespace, federatedGraphName, federatedGraphRoutingURL, subgraphName, subgraphRoutingURL, subgraphSchema),
+				Destroy: true,
+			},
+			{
+				Config: testAccSubgraphDataSourceConfigWithoutSchema(namespace, federatedGraphName, federatedGraphRoutingURL, subgraphName, subgraphRoutingURL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "name", subgraphName),
+					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "namespace", namespace),
+					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "routing_url", subgraphRoutingURL),
+					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "labels.team", "backend"),
+					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "labels.stage", "dev"),
+					resource.TestCheckNoResourceAttr("data.cosmo_subgraph.test", "subscription_url"),
+					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "subscription_protocol", "ws"),
+					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "websocket_subprotocol", "auto"),
+					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "is_event_driven_graph", "false"),
+					resource.TestCheckResourceAttr("data.cosmo_subgraph.test", "schema", ""),
 				),
 			},
 		},
 	})
 }
 
-func testAccSubgraphDataSourceConfig(namespace, federatedGraphName, federatedGraphroutingURL, subgraphName, subgraphRoutingURL string) string {
+func testAccSubgraphDataSourceConfig(namespace, federatedGraphName, federatedGraphroutingURL, subgraphName, subgraphRoutingURL, subgraphSchema string) string {
+	return fmt.Sprintf(`
+resource "cosmo_namespace" "test" {
+  name = "%s"
+}
+
+resource "cosmo_federated_graph" "test" {
+  name      	= "%s"
+  namespace 	= cosmo_namespace.test.name
+  routing_url 	= "%s"
+}
+
+resource "cosmo_subgraph" "test" {
+  name                = "%s"
+  namespace           = cosmo_namespace.test.name
+  routing_url         = "%s"
+  labels              = { "team" = "backend", "stage" = "dev" }
+  schema              = <<-EOT
+%sEOT
+}
+
+data "cosmo_subgraph" "test" {
+  name      = cosmo_subgraph.test.name
+  namespace = cosmo_subgraph.test.namespace
+}
+`, namespace, federatedGraphName, federatedGraphroutingURL, subgraphName, subgraphRoutingURL, subgraphSchema)
+}
+
+func testAccSubgraphDataSourceConfigWithoutSchema(namespace, federatedGraphName, federatedGraphroutingURL, subgraphName, subgraphRoutingURL string) string {
 	return fmt.Sprintf(`
 resource "cosmo_namespace" "test" {
   name = "%s"

--- a/internal/service/subgraph/errors.go
+++ b/internal/service/subgraph/errors.go
@@ -5,6 +5,7 @@ const (
 	ErrCreatingSubgraph          = "Error Creating Subgraph"
 	ErrRetrievingSubgraph        = "Error Retrieving Subgraph"
 	ErrRetrievingSubgraphs       = "Error Retrieving Subgraphs"
+	ErrRetrievingSubgraphSchema  = "Error Retrieving Subgraph Schema"
 	ErrUpdatingSubgraph          = "Error Updating Subgraph"
 	ErrDeletingSubgraph          = "Error Deleting Subgraph"
 	ErrPublishingSubgraph        = "Error Publishing Subgraph"


### PR DESCRIPTION
### Description

This PR fixes the cosmo_subgraph datasource. It was missing to retrieve the schema for the subgraph and therefore the attribute was not usable