### PR TITLE
fix: allow creation of event driven subgraphs

### DIFF
--- a/docs/resources/subgraph.md
+++ b/docs/resources/subgraph.md
@@ -31,7 +31,6 @@ resource "cosmo_subgraph" "test" {
 ### Required
 
 - `name` (String) The name of the subgraph.
-- `routing_url` (String) The routing URL of the subgraph.
 
 ### Optional
 
@@ -39,6 +38,7 @@ resource "cosmo_subgraph" "test" {
 - `labels` (Map of String) Labels for the subgraph.
 - `namespace` (String) The namespace in which the subgraph is located.
 - `readme` (String) The readme for the subgraph.
+- `routing_url` (String) The routing URL of the subgraph. Routing URL is required for normal subgraphs but not for event driven subgraphs.
 - `schema` (String) The schema for the subgraph.
 - `subscription_protocol` (String) The subscription protocol for the subgraph.
 - `subscription_url` (String) The subscription URL for the subgraph.

--- a/internal/acceptance/testing.go
+++ b/internal/acceptance/testing.go
@@ -704,4 +704,92 @@ type Volume {
   cubic_meters: Int
 }
 `
+
+	TestAccValidEventDrivenSubgraphSchema = `
+directive @edfs__natsRequest(subject: String!, providerId: String! = "default") on FIELD_DEFINITION
+directive @edfs__natsPublish(subject: String!, providerId: String! = "default") on FIELD_DEFINITION
+directive @edfs__natsSubscribe(subjects: [String!]!, providerId: String! = "default", streamConfiguration: edfs__NatsStreamConfiguration) on FIELD_DEFINITION
+directive @openfed__subscriptionFilter(condition: openfed__SubscriptionFilterCondition!) on FIELD_DEFINITION
+directive @edfs__kafkaPublish(topic: String!, providerId: String! = "default") on FIELD_DEFINITION
+directive @edfs__kafkaSubscribe(topics: [String!]!, providerId: String! = "default") on FIELD_DEFINITION
+directive @edfs__redisPublish(channel: String!, providerId: String! = "default") on FIELD_DEFINITION
+directive @edfs__redisSubscribe(channels: [String!]!, providerId: String! = "default") on FIELD_DEFINITION
+
+scalar openfed__SubscriptionFilterValue
+
+input openfed__SubscriptionFieldCondition {
+    fieldPath: String!
+    values: [openfed__SubscriptionFilterValue]!
+}
+
+input openfed__SubscriptionFilterCondition {
+    AND: [openfed__SubscriptionFilterCondition!]
+    IN: openfed__SubscriptionFieldCondition
+    NOT: openfed__SubscriptionFilterCondition
+    OR: [openfed__SubscriptionFilterCondition!]
+}
+
+type Query {
+    employeeFromEvent(id: Int!): Employee! @edfs__natsRequest(subject: "getEmployee.{{ args.id }}")
+    employeeFromEventMyNats(employeeID: Int!): Employee! @edfs__natsRequest(subject: "getEmployeeMyNats.{{ args.employeeID }}", providerId: "my-nats")
+}
+
+input UpdateEmployeeInput {
+    name: String
+    email: String
+}
+
+type Mutation {
+    updateEmployeeMyKafka(employeeID: Int!, update: UpdateEmployeeInput!): edfs__PublishResult! @edfs__kafkaPublish(topic: "employeeUpdated", providerId: "my-kafka")
+    updateEmployeeMyNats(id: Int!, update: UpdateEmployeeInput!): edfs__PublishResult! @edfs__natsPublish(subject: "employeeUpdatedMyNats.{{ args.id }}", providerId: "my-nats")
+    updateEmployeeMyRedis(id: Int!, update: UpdateEmployeeInput!): edfs__PublishResult! @edfs__redisPublish(channel: "employeeUpdatedMyRedis", providerId: "my-redis")
+    updateEmployeeMyRedisOnCustomChannel(id: Int!, update: UpdateEmployeeInput!): edfs__PublishResult! @edfs__redisPublish(channel: "employeeUpdatedMyRedis.{{ args.id }}", providerId: "my-redis")
+}
+
+type Subscription {
+    employeeUpdated(employeeID: Int!): Employee! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.employeeID }}"])
+    employeeUpdatedMyKafka(employeeID: Int!): Employee! @edfs__kafkaSubscribe(topics: ["employeeUpdated", "employeeUpdatedTwo"], providerId: "my-kafka")
+    employeeUpdatedMyNats(id: Int!): Employee! @edfs__natsSubscribe(subjects: ["employeeUpdatedMyNats.{{ args.id }}", "employeeUpdatedMyNatsTwo.{{ args.id }}"], providerId: "my-nats")
+    employeeUpdatedNatsStream(id: Int!): Employee! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.id }}"], streamConfiguration: { consumerName: "consumerName", streamName: "streamName"})
+    employeeUpdatedMyRedis(id: Int!): Employee! @edfs__redisSubscribe(channels: ["employeeUpdatedMyRedis.{{ args.id }}"], providerId: "my-redis")
+    employeeUpdates: Employee! @edfs__redisSubscribe(channels: ["employeeUpdatedMyRedis"], providerId: "my-redis")
+    filteredEmployeeUpdated(id: Int!): Employee!
+        @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.id }}"])
+        @openfed__subscriptionFilter(condition: { NOT: { IN: { fieldPath: "id", values: [2, 6, 9, 10, 12] } } })
+    filteredEmployeeUpdatedMyKafka(employeeID: ID!): Employee!
+        @edfs__kafkaSubscribe(topics: ["employeeUpdated", "employeeUpdatedTwo"], providerId: "my-kafka")
+        @openfed__subscriptionFilter(condition: { IN: { fieldPath: "id", values: [1, 3, 4, 7, 11] } })
+    filteredEmployeeUpdatedMyKafkaWithListFieldArguments(firstIds: [ID!]!, secondIds: [ID!]!): Employee!
+        @edfs__kafkaSubscribe(topics: ["employeeUpdated", "employeeUpdatedTwo"], providerId: "my-kafka")
+        @openfed__subscriptionFilter(condition: { IN: { fieldPath: "id", values: ["{{ args.firstIds }}", "{{ args.secondIds }}"] } })
+    filteredEmployeeUpdatedMyKafkaWithNestedListFieldArgument(input: KafkaInput!): Employee!
+        @edfs__kafkaSubscribe(topics: ["employeeUpdated", "employeeUpdatedTwo"], providerId: "my-kafka")
+        @openfed__subscriptionFilter(condition: {
+            OR: [
+                { IN: { fieldPath: "id", values: ["{{ args.input.ids }}"] } },
+                { IN: { fieldPath: "id", values: ["1"] } },
+            ],
+        })
+    filteredEmployeeUpdatedMyRedis(ids: [ID!]!): Employee!
+        @edfs__redisSubscribe(channels: ["employeeUpdatedMyRedis"], providerId: "my-redis")
+        @openfed__subscriptionFilter(condition: { IN: { fieldPath: "id", values: ["{{ args.ids }}"] } })
+}
+
+input KafkaInput {
+    ids: [Int!]!
+}
+
+type Employee @key(fields: "id", resolvable: false) {
+  id: Int! @external
+}
+
+type edfs__PublishResult {
+    success: Boolean!
+}
+
+input edfs__NatsStreamConfiguration {
+    consumerInactiveThreshold: Int! = 30
+    consumerName: String!
+    streamName: String!
+}`
 )

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -10,8 +10,12 @@ const (
 	GraphQLWebsocketSubprotocolGraphQLTransportWS = "graphql-transport-ws"
 )
 
-func ResolveWebsocketSubprotocol(protocol string) *common.GraphQLWebsocketSubprotocol {
-	switch protocol {
+func ResolveWebsocketSubprotocol(protocol *string) *common.GraphQLWebsocketSubprotocol {
+	if protocol == nil {
+		return nil
+	}
+
+	switch *protocol {
 	case GraphQLWebsocketSubprotocolGraphQLWS:
 		return common.GraphQLWebsocketSubprotocol_GRAPHQL_WEBSOCKET_SUBPROTOCOL_WS.Enum()
 	case GraphQLWebsocketSubprotocolGraphQLTransportWS:
@@ -28,8 +32,12 @@ const (
 	GraphQLSubscriptionProtocolSSEPost = "sse_post"
 )
 
-func ResolveSubscriptionProtocol(protocol string) *common.GraphQLSubscriptionProtocol {
-	switch protocol {
+func ResolveSubscriptionProtocol(protocol *string) *common.GraphQLSubscriptionProtocol {
+	if protocol == nil {
+		return nil
+	}
+
+	switch *protocol {
 	case GraphQLSubscriptionProtocolSSE:
 		return common.GraphQLSubscriptionProtocol_GRAPHQL_SUBSCRIPTION_PROTOCOL_SSE.Enum()
 	case GraphQLSubscriptionProtocolSSEPost:

--- a/internal/api/monograph.go
+++ b/internal/api/monograph.go
@@ -16,8 +16,8 @@ func (p *PlatformClient) CreateMonograph(ctx context.Context, name string, names
 		GraphUrl:               graphURL,
 		SubscriptionUrl:        subscriptionURL,
 		Readme:                 readme,
-		WebsocketSubprotocol:   ResolveWebsocketSubprotocol(websocketSubprotocol),
-		SubscriptionProtocol:   ResolveSubscriptionProtocol(subscriptionProtocol),
+		WebsocketSubprotocol:   ResolveWebsocketSubprotocol(&websocketSubprotocol),
+		SubscriptionProtocol:   ResolveSubscriptionProtocol(&subscriptionProtocol),
 		AdmissionWebhookURL:    admissionWebhookURL,
 		AdmissionWebhookSecret: &admissionWebhookSecret,
 	})
@@ -46,8 +46,8 @@ func (p *PlatformClient) UpdateMonograph(ctx context.Context, name string, names
 		GraphUrl:               graphURL,
 		SubscriptionUrl:        subscriptionURL,
 		Readme:                 readme,
-		WebsocketSubprotocol:   ResolveWebsocketSubprotocol(websocketSubprotocol),
-		SubscriptionProtocol:   ResolveSubscriptionProtocol(subscriptionProtocol),
+		WebsocketSubprotocol:   ResolveWebsocketSubprotocol(&websocketSubprotocol),
+		SubscriptionProtocol:   ResolveSubscriptionProtocol(&subscriptionProtocol),
 		AdmissionWebhookURL:    &admissionWebhookURL,
 		AdmissionWebhookSecret: &admissionWebhookSecret,
 	})

--- a/internal/service/feature-subgraph/resource_cosmo_feature_subgraph.go
+++ b/internal/service/feature-subgraph/resource_cosmo_feature_subgraph.go
@@ -301,8 +301,8 @@ func (r *FeatureSubgraphResource) Update(ctx context.Context, req resource.Updat
 		RoutingUrl:           planData.RoutingURL.ValueStringPointer(),
 		Labels:               nil,
 		SubscriptionUrl:      &subscriptionUrl,
-		SubscriptionProtocol: api.ResolveSubscriptionProtocol(subscriptionProtocol),
-		WebsocketSubprotocol: api.ResolveWebsocketSubprotocol(websocketSubprotocol),
+		SubscriptionProtocol: api.ResolveSubscriptionProtocol(&subscriptionProtocol),
+		WebsocketSubprotocol: api.ResolveWebsocketSubprotocol(&websocketSubprotocol),
 		Readme:               &readme,
 		Headers:              []string{},
 	})
@@ -446,8 +446,8 @@ func (r *FeatureSubgraphResource) createAndPublishFeatureSubgraph(ctx context.Co
 		IsFeatureSubgraph:    &isFeatureSubgraph,
 		SubscriptionUrl:      data.SubscriptionURL.ValueStringPointer(),
 		Readme:               data.Readme.ValueStringPointer(),
-		SubscriptionProtocol: api.ResolveSubscriptionProtocol(data.SubscriptionProtocol.ValueString()),
-		WebsocketSubprotocol: api.ResolveWebsocketSubprotocol(data.WebsocketSubprotocol.ValueString()),
+		SubscriptionProtocol: api.ResolveSubscriptionProtocol(data.SubscriptionProtocol.ValueStringPointer()),
+		WebsocketSubprotocol: api.ResolveWebsocketSubprotocol(data.WebsocketSubprotocol.ValueStringPointer()),
 	}
 
 	apiErr := r.client.CreateSubgraph(ctx, requestData)

--- a/internal/service/subgraph/resource_cosmo_subgraph.go
+++ b/internal/service/subgraph/resource_cosmo_subgraph.go
@@ -339,7 +339,7 @@ func (r *SubgraphResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	readme := utils.GetValueOrDefault(data.Readme.ValueStringPointer(), "")
-	subscriptionUrl := data.SubscriptionUrl.ValueStringPointer()
+	subscriptionUrl := data.SubscriptionUrl.ValueString()
 	routingUrl := data.RoutingURL.ValueStringPointer()
 
 	requestData := &platformv1.UpdateSubgraphRequest{
@@ -348,7 +348,7 @@ func (r *SubgraphResource) Update(ctx context.Context, req resource.UpdateReques
 		Namespace:            data.Namespace.ValueString(),
 		Labels:               labels,
 		UnsetLabels:          unsetLabels,
-		SubscriptionUrl:      subscriptionUrl,
+		SubscriptionUrl:      &subscriptionUrl,
 		SubscriptionProtocol: api.ResolveSubscriptionProtocol(data.SubscriptionProtocol.ValueStringPointer()),
 		WebsocketSubprotocol: api.ResolveWebsocketSubprotocol(data.WebsocketSubprotocol.ValueStringPointer()),
 		Readme:               &readme,

--- a/internal/service/subgraph/resource_cosmo_subgraph.go
+++ b/internal/service/subgraph/resource_cosmo_subgraph.go
@@ -99,10 +99,9 @@ For more information on subgraphs, please refer to the [Cosmo Documentation](htt
 				},
 			},
 			"routing_url": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-				MarkdownDescription: `The routing URL of the subgraph. 
-				Routing URL is required for normal subgraphs but not for event driven subgraphs.`,
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The routing URL of the subgraph. Routing URL is required for normal subgraphs but not for event driven subgraphs.",
 			},
 			"subscription_url": schema.StringAttribute{
 				Optional:            true,


### PR DESCRIPTION
This pull request introduces support for event-driven subgraphs, refines the handling of subgraph attributes based on their type, and improves protocol resolution logic throughout the codebase. The main changes can be grouped into documentation updates, resource and API logic improvements, and expanded testing.

**Support for event-driven subgraphs and improved protocol handling:**

*Documentation and resource schema updates:*

- Updated the documentation and resource schema for `cosmo_subgraph` to clarify that `routing_url` is required only for normal subgraphs and optional for event-driven subgraphs. The field is now marked as optional and computed. [[1]](diffhunk://#diff-c07f38d39bfbea1763d4fcc92f54947f82d3fb7484ff901637bb77f742468590L34-R41) [[2]](diffhunk://#diff-249ce761c02c86af17833049b154ca0e50a4b9260e518500a4ba1abe0cf09593L102-R104)

*Resource and API logic improvements:*

- Modified resource creation and update logic so that, for event-driven subgraphs, fields such as `routing_url`, `subscription_url`, `subscription_protocol`, and `websocket_subprotocol` are omitted from requests and set to null, ensuring correct API usage. [[1]](diffhunk://#diff-249ce761c02c86af17833049b154ca0e50a4b9260e518500a4ba1abe0cf09593L341-R365) [[2]](diffhunk://#diff-249ce761c02c86af17833049b154ca0e50a4b9260e518500a4ba1abe0cf09593L512-R536)
- Refactored protocol resolution functions (`ResolveWebsocketSubprotocol`, `ResolveSubscriptionProtocol`) to accept pointer types, allowing for proper handling of optional protocol fields and avoiding default assignments when fields are omitted. Updated all relevant resource and API calls to use the new pointer-based logic. [[1]](diffhunk://#diff-6ef968a68ef934716aa68f613ec2bc403f9d1cb367cf518ead852b8a33e5eedaL13-R18) [[2]](diffhunk://#diff-6ef968a68ef934716aa68f613ec2bc403f9d1cb367cf518ead852b8a33e5eedaL31-R40) [[3]](diffhunk://#diff-d772372078642493a73d0b39dc05fbc74b0e5fef7e276324a222c82c5fb42071L19-R20) [[4]](diffhunk://#diff-d772372078642493a73d0b39dc05fbc74b0e5fef7e276324a222c82c5fb42071L49-R50) [[5]](diffhunk://#diff-28fd0a14720d1dc9a67bdb503a1aaae58d93ccf9d54c2ce0cb6e7d6c678994b9L304-R305) [[6]](diffhunk://#diff-28fd0a14720d1dc9a67bdb503a1aaae58d93ccf9d54c2ce0cb6e7d6c678994b9L449-R450)

*Testing and validation:*

- Added a new acceptance test (`TestAccSubgraphEventDrivenSubgraph`) and supporting configuration function to validate the creation and management of event-driven subgraphs, ensuring that omitted fields behave as expected. [[1]](diffhunk://#diff-6e24f527d177b454d950346b6899174516b181bb22d86fdf54991ba3c0bbf0bdR275-R307) [[2]](diffhunk://#diff-6e24f527d177b454d950346b6899174516b181bb22d86fdf54991ba3c0bbf0bdR443-R469)

*Schema enhancements for event-driven subgraphs:*

- Introduced a comprehensive test schema (`TestAccValidEventDrivenSubgraphSchema`) with various event-driven directives and types to support robust testing of event-driven subgraph features.